### PR TITLE
Add Hot-Module Replacement, uglification, and source maps

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,14 @@
 WIP
 
+Assorted features:
+
+- Written using [Typescript](https://www.typescriptlang.org/), [Angular 1](https://angularjs.org/) and [Ionic](http://ionicframework.com/)
+- Minification with [UglifyJS](https://github.com/mishoo/UglifyJS)
+- Built with [Webpack](https://webpack.github.io/)
+- Source maps (via Typescript and Webpack)
+- Type definitions via [typings](https://github.com/typings/typings)
+- Builds available for browser, desktop [Electron](http://electron.atom.io/), iOS, and Android
+
 ## Install
 
 ```
@@ -11,11 +20,14 @@ ionic state restore
 
 ```
 npm run browser
+npm run browser-watch
 npm run desktop
 npm run android
 npm run ios
 npm run iosEmulator
 ```
+
+Note: When using the `browser` or `browser-watch` scripts, point your browser to [http://localhost:8000](http://localhost:8000).
 
 ## List of Cordova plugins that support the browser platform
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "dumpprod": "rm -rf www/* && webpack --release --config webpack.config.prod.js",
     "watch": "rm -rf www/* && webpack --watch --progress --colors --config webpack.config.browser.js",
     "browser": "npm run dumpdev -- --config webpack.config.browser.js && cordova run browser",
+    "browser-watch": "rm -rf www/* && webpack-dev-server --progress --colors --inline --hot --config webpack.config.browser.js",
     "desktop": "npm run dumpdev -- --config webpack.config.desktop.js  && cordova build browser && electron ./platforms/browser/www/index.desktop.js",
     "android": "npm run dumpdev -- --config webpack.config.android.js  && cordova run android",
     "iosEmulator": "npm run dumpdev -- --config webpack.config.ios.js  && cordova run ios",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "style-loader": "^0.13.0",
     "ts-loader": "^0.7.2",
     "typescript": "^1.7.3",
+    "uglify-js": "^2.6.2",
     "webpack": "^1.12.9",
     "webpack-dev-server": "^1.14.0"
   },

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "dumpprod": "rm -rf www/* && webpack --release --config webpack.config.prod.js",
     "watch": "rm -rf www/* && webpack --watch --progress --colors --config webpack.config.browser.js",
     "browser": "npm run dumpdev -- --config webpack.config.browser.js && cordova run browser",
-    "browser-watch": "rm -rf www/* && webpack-dev-server --progress --colors --inline --hot --config webpack.config.browser.js",
+    "browser-watch": "rm -rf www/* && webpack-dev-server --progress --colors --inline --hot --port 8000 --config webpack.config.browser.js",
     "desktop": "npm run dumpdev -- --config webpack.config.desktop.js  && cordova build browser && electron ./platforms/browser/www/index.desktop.js",
     "android": "npm run dumpdev -- --config webpack.config.android.js  && cordova run android",
     "iosEmulator": "npm run dumpdev -- --config webpack.config.ios.js  && cordova run ios",

--- a/webpack.config.browser.js
+++ b/webpack.config.browser.js
@@ -8,4 +8,6 @@ webpackConfig.plugins.push(new webpack.DefinePlugin({
     IS_DESKTOP: false
 }));
 
+webpackConfig.devtool = 'source-map';
+
 module.exports = webpackConfig;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -60,6 +60,7 @@ module.exports = {
             filename: 'index.html',
             pkg: pkg,
             template: path.join(libPath, 'index.html')
-        })
+        }),
+        new webpack.optimize.UglifyJsPlugin()
     ]
 };


### PR DESCRIPTION
Add an NPM script that uses `webpack-dev-server` to provide a
HMR-enabled server on port 8080.  Note: While the HMR support is
awesome, in its current state, this workflow doesn’t include
`cordova.js`.  A future TODO would be to consider webpack-cordova-plugin
(https://github.com/markmarijnissen/webpack-cordova-plugin) as a
solution for this.
